### PR TITLE
add operation limit for MSGDLY PV

### DIFF
--- a/tprTriggerApp/Db/tprDiag.db
+++ b/tprTriggerApp/Db/tprDiag.db
@@ -140,6 +140,8 @@ record(ao, "TPR:$(LOCA):$(IOC_UNIT):$(INST):MSGDLY")
     field(EGU,  "nsec")
     field(VAL, "107692.3076923077")
     field(PREC, "0")
+    field(HOPR, "$(DLYLIMIT=)")
+    field(DRVH, "$(DLYLIMIT=)")
     field(PINI, "YES")
     info(autosaveFields, "VAL")
 }

--- a/tprTriggerApp/Db/tprTrig.substitutions
+++ b/tprTriggerApp/Db/tprTrig.substitutions
@@ -1,8 +1,8 @@
 # $(DEV)
 
 file "tprDiag.db" {
-    pattern {    SPACE_HOLDER        }
-            {   "SPACE_HOLDER"       } 
+    pattern {    SPACE_HOLDER,  DLYLIMIT }
+            {   "SPACE_HOLDER", "136760" }
 }
 
 file "tprChannel.db" {

--- a/tprTriggerApp/Db/tprTrig_ued.substitutions
+++ b/tprTriggerApp/Db/tprTrig_ued.substitutions
@@ -1,8 +1,8 @@
 # $(DEV)
 
 file "tprDiag.db" {
-    pattern {    SPACE_HOLDER        }
-            {   "SPACE_HOLDER"       } 
+    pattern {    SPACE_HOLDER,   DLYLIMIT }
+            {   "SPACE_HOLDER",  "254000" }
 }
 
 file "tprChannel_ued.db" {


### PR DESCRIPTION
Kukhee's support for setting HOPR and DRVH  limit fields via tprTrig.substitutions and tprTrig_ued.substitutions.