### PR TITLE
Channel count fix and max soft ev to 12

### DIFF
--- a/tprTriggerApp/src/pcieTpr.cpp
+++ b/tprTriggerApp/src/pcieTpr.cpp
@@ -28,7 +28,7 @@
 #include <dbScan.h>
 
 #include "pcieTpr.h"
-
+#include "tprTriggerAsynDriver.h"
 
 
 static const char *name_s[] = { "tprA", 

--- a/tprTriggerApp/src/pcieTpr.cpp
+++ b/tprTriggerApp/src/pcieTpr.cpp
@@ -31,6 +31,8 @@
 #include "tprTriggerAsynDriver.h"
 
 
+int DEBUG_PCIE_TPR  = 1;
+
 static const char *name_s[] = { "tprA", 
                                 "tprB",
                                 "tprC",
@@ -207,7 +209,8 @@ static void tprChannelFunc(void *param)
 
 
         if(prev_allrp == allrp) {   // there is no update
-            printf("%s thread %s is notified but, no new pattern\n", p->thread_name, p->file_name);
+            if ( DEBUG_PCIE_TPR >= 2 )
+                printf("%s thread %s is notified but, no new pattern\n", p->thread_name, p->file_name);
             epicsThreadSleep(1.);
             continue;
         }
@@ -358,18 +361,23 @@ void *  pcieTprInit(char *dev_prefix)
         if(!strcmp(dev_prefix, dev_s[dev_idx])) break;
     }
 
-    if(!dev_s[dev_idx]) return (void *) NULL;
+    if(!dev_s[dev_idx])
+    {
+        printf( "pcieTprInit(%s): dev_s[%d] is NULL\n", dev_prefix, dev_idx );
+        return (void *) NULL;
+    }
 
+    if ( DEBUG_PCIE_TPR >= 1 )
+        printf( "pcieTprInit(%s): dev_idx=%d\n", dev_prefix, dev_idx );
     for(ch_idx = 0; dev_c[ch_idx]; ch_idx++) {
         ev_num = ev_prefix[dev_idx] + ch_idx;
         sprintf(file_name, "%s%c", dev_s[dev_idx], dev_c[ch_idx]);
         sprintf(thrd_name, "%s%c", name_s[dev_idx], dev_c[ch_idx]);
 
-
+        if ( DEBUG_PCIE_TPR >= 2 )
+            printf( "pcieTprInit: calling createPcieThread(%s, %s, ev %d, ch %d\n", thrd_name, file_name, ev_num, ch_idx );
         createPcieThread(thrd_name, file_name, ev_num, ch_idx);
     }
-
-
 
     return (void*) NULL;
 }
@@ -435,7 +443,8 @@ void  pcieTprInitSoftEv(void)
 
 void * pcieTprGPWrapper(void)
 {
-    printf("Found PCIeTPR: execute GPWrapperInit()\n");
+    if ( DEBUG_PCIE_TPR >= 1 )
+        printf("Found PCIeTPR: execute GPWrapperInit()\n");
 
     generalTimeRegisterEventProvider("pcieTprTimeGet",       1000, (TIMEEVENTFUN) pcieTprTimeGet_gtWrapper);
     generalTimeRegisterEventProvider("pcieTprTimeGetSystem", 2000, (TIMEEVENTFUN) pcieTprTimeGetSystem_gtWrapper);
@@ -450,7 +459,16 @@ TimingPulseId timingGetLastFiducial(void)
 {
     uint64_t pid64;
     ts_tbl_t *p = &(ts_tbl[0]);
-
+    if ( p == NULL )
+    {
+        printf( "timingGetLastFiducial: Invalid timestamp table! p = %p\n", p );
+        return 0LL;
+    }
+    if ( p->plock == NULL )
+    {
+        printf( "timingGetLastFiducial: Invalid timestamp table lock! p->plock = %p\n", p->plock );
+        return 0LL;
+    }
     p->plock->lock();
     pid64 = p->pid64;
     p->plock->unlock();

--- a/tprTriggerApp/src/pcieTpr.h
+++ b/tprTriggerApp/src/pcieTpr.h
@@ -9,7 +9,6 @@
 #define  RESERVED_CH    13
 #define  EV360HZ_CH     RESERVED_CH
 #define  EV360HZ_EV      1
-#define  MAX_SOFT_EV     8
 
 extern "C" {
 

--- a/tprTriggerApp/src/tprTriggerAsynDriver.cpp
+++ b/tprTriggerApp/src/tprTriggerAsynDriver.cpp
@@ -1243,7 +1243,8 @@ static int tprTriggerAsynDriverInitialize(void)
     init_pList();
 
     if(!ellCount(pList)) return 0;
-    
+
+    printf( "tprTriggerAsynDriverInitialize: Creating tprTriggerMon thread.\n" );
     epicsThreadCreate("tprTriggerMon", epicsThreadPriorityLow,
                       epicsThreadGetStackSize(epicsThreadStackMedium),
                       (EPICSTHREADFUNC) tprTriggerAsynDriverMonitor, 0);

--- a/tprTriggerApp/src/tprTriggerAsynDriver.cpp
+++ b/tprTriggerApp/src/tprTriggerAsynDriver.cpp
@@ -39,7 +39,6 @@
 
 #include <yamlLoader.h>
 
-#include <tprTriggerYaml.hh>
 #include <tprTriggerAsynDriver.h>
 
 #include "pcieTpr.h"

--- a/tprTriggerApp/src/tprTriggerAsynDriver.cpp
+++ b/tprTriggerApp/src/tprTriggerAsynDriver.cpp
@@ -168,7 +168,6 @@ tprTriggerAsynDriver::tprTriggerAsynDriver(const char *portName, const char *cor
     application_clock_1 = 119.;         // 119MHz as a default for LCLS1
     application_clock_2 = (1300./7.);   // 186MHz as a default for LCLS2
     
-    _update_flag =0;
 
 
     if(tprValidChannels > 0 && tprValidChannels < 16) {
@@ -298,17 +297,14 @@ void tprTriggerAsynDriver::Monitor(void)
     val = pApiDrv->frameVersion();  setIntegerParam(p_frame_version, val);
     
     for(int i=0; i< valid_chns; i++) {
-        val = pApiDrv->channelCount(i); setIntegerParam((p_channel_st+i)->p_counter, val);
-        if(_update_flag) {
-            if(val >= _prev_chn_counter[i]) { 
-                epicsFloat64 _rate = (val - _prev_chn_counter[i])/2.;
-                setDoubleParam((p_channel_st+i)->p_rate, _rate);
-            }
-            _prev_chn_counter[i] = val;
-        }
+        uint32_t _newRate = pApiDrv->channelCount(i);
+        epicsFloat64 _rate = _newRate;
+        setDoubleParam((p_channel_st+i)->p_rate, _rate);
+
+        uint32_t _newCount = _prev_chn_counter[i] + _newRate;
+        setIntegerParam((p_channel_st+i)->p_counter, _newCount);
+        _prev_chn_counter[i] = _newCount;
     }
-    
-    _update_flag = _update_flag?0:1;
     
     callParamCallbacks();
 }

--- a/tprTriggerApp/src/tprTriggerAsynDriver.h
+++ b/tprTriggerApp/src/tprTriggerAsynDriver.h
@@ -18,6 +18,8 @@
 
 #include <ellLib.h>
 
+#include <tprTriggerYaml.hh>
+#define  MAX_SOFT_EV     12
 
 class tprTriggerAsynDriver:asynPortDriver {
     public:
@@ -183,7 +185,7 @@ class tprTriggerAsynDriver:asynPortDriver {
         struct {
            int p_ev_enable;
            int p_ev;
-        } p_soft_event_st[8];
+        } p_soft_event_st[MAX_SOFT_EV];
 
         int p_ued_special;        /* asynInt32 */
         


### PR DESCRIPTION
These are the tprTriggerApp/src commits I made in Nov 2022 for release R2.5.3-5.0.
It bumps MAX_SOFT_EV to 12 so there's 12 channels, 12 trigger and 12 soft events.
This is needed for some db work also in R2.5.3-5.0 that creates a default 1:1:1 mapping
that allows easier control via 12 embedded edm panels.

It also fixes the channelCount implementation and adds additional flag enabled diagnostic messages
to make for easier debugging when errors occur.