### PR TITLE
Dev tpr info

### DIFF
--- a/README
+++ b/README
@@ -105,7 +105,34 @@ But, some of cases, we don't need to put the ":"
 ex) BPMS:LI26:201:CALB
 
 
+How to load devTprInfo.db and/or devEvrInfo.db:
+These files provide PVs that allow edm screens and python programs to support IOCs w/ either EVR or TPR support.
+If you load both, your python or edm can test both $(DEV):TprUsed and $(DEV):EvrUsed to see which one, if any, is used.
+Macros for devTprInfo.db:
+DEV		- This DEV is not the TPR device prefix, but instead the higher level device such as a camera.
+TPR_USED- 0 = Unused, 1 = Used
+TPR_PV	- This is the TPR device prefix
+TPS_PV	- This is the TPR event prefix
+TPR_TR	- TPR trigger number, defaults to 0
+TPR_CH	- TPR channel number, defaults to TPR_TR
 
+example st.cmd lines for TPR, but no EVR)
+# Load both devEvrInfo.db and devTprInfo.db so python programs can test for both sets of PVs
+dbLoadRecords( "db/devEvrInfo.db",  "DEV=$(CAM_PV),EVR_USED=0" )
+dbLoadRecords( "db/devTprInfo.db",  "DEV=$(CAM_PV),TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=$(TPR_CH),TPR_TR=$(TPR_TR),TPR_SE=$(TPR_SE),TPR_USED=1" )
+
+example using syntax for templated IOC build support)
+# Load both devEvrInfo.db and devTprInfo.db so python programs can test for both sets of PVs
+$$IF(EVR_PV)
+dbLoadRecords( "db/devEvrInfo.db",  "DEV=$(CAM_PV),EVR=$(EVR_PV),TRIG_CH=$$IF(EVR_TRIG,$$EVR_TRIG,0),EVR_USED=1" )
+$$ELSE(EVR_PV)
+dbLoadRecords( "db/devEvrInfo.db",  "DEV=$(CAM_PV),EVR_USED=0" )
+$$ENDIF(EVR_PV)
+$$IF(TPR_PV)
+dbLoadRecords( "db/devTprInfo.db",  "DEV=$(CAM_PV),TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=$(TPR_CH),TPR_TR=$(TPR_TR),TPR_SE=$(TPR_SE),TPR_USED=1" )
+$$ELSE(TPR_PV)
+dbLoadRecords( "db/devTprInfo.db",  "DEV=$(CAM_PV),TPR_USED=0" )
+$$ENDIF(TPR_PV)
 
 2. how to initialize the driver
 

--- a/tprTriggerApp/Db/Makefile
+++ b/tprTriggerApp/Db/Makefile
@@ -10,6 +10,7 @@ include $(TOP)/configure/CONFIG
 #----------------------------------------------------
 # Create and install (or just install)
 # databases, templates, substitutions like this
+DB += devTprInfo.db
 DB += pcie_tprTrig.db
 DB += pcieSlave_tprTrig.db
 DB += tprTrig.db

--- a/tprTriggerApp/Db/devTprInfo.db
+++ b/tprTriggerApp/Db/devTprInfo.db
@@ -79,7 +79,6 @@ record( bo, "$(TPS_PV=$(DEV):NoTpr):TprUsed" )
 record(mbbi, "$(TPS_PV=$(DEV):NoTpr):RXLNKSTATUS" )
 {
   field(PINI, "YES")
-  field(INP,  "$(TPR_PV=$(DEV):NoTpr):RXLNKSTATUS CP NMS")
   field(ZRVL, "0")
   field(ZRST, "Link Down")
   field(ZRSV, "MAJOR")

--- a/tprTriggerApp/Db/devTprInfo.db
+++ b/tprTriggerApp/Db/devTprInfo.db
@@ -11,10 +11,10 @@
 # Optional macros:
 #	TPR_PV			TPR master PV prefix, defaults to $(DEV):NoTpr
 #	TPS_PV			TPR slave  PV prefix, defaults to $(DEV):NoTpr
-#	TPR_CH			TPR channel number, defaults to 0
 #	TPR_TR			TPR trigger number, defaults to 0
+#	TPR_CH			TPR channel number, defaults to TPR_TR
 #
-# It adds 3 new PVs for each device
+# It adds 4 new PVs for each device
 #	$(DEV):TPR_PV		PV prefix for this device's master TPR
 #	$(DEV):TPS_PV		PV prefix for this device's slave  TPR
 #	$(DEV):TPR_CH		TPR Channel number for this device
@@ -58,7 +58,7 @@ record( stringout, "$(DEV):TPS_PV" )
 record( longout, "$(DEV):TPR_CH" )
 {
 	field( PINI, "YES" )
-	field( VAL, "$(TPR_CH=0)" )
+	field( VAL, "$(TPR_CH=$(TPR_TR=0))" )
 }
 
 record( longout, "$(DEV):TPR_TR" )
@@ -76,10 +76,10 @@ record( bo, "$(TPS_PV=$(DEV):NoTpr):TprUsed" )
 }
 
 # Must match RXLNKSTATUS from tprTrigger module pcieSlave_tprTrig.db
-record(mbbi, "$(TPS_PV):RXLNKSTATUS")
+record(mbbi, "$(TPS_PV=$(DEV):NoTpr):RXLNKSTATUS" )
 {
   field(PINI, "YES")
-  field(INP,  "$(TPR_PV):RXLNKSTATUS CP NMS")
+  field(INP,  "$(TPR_PV=$(DEV):NoTpr):RXLNKSTATUS CP NMS")
   field(ZRVL, "0")
   field(ZRST, "Link Down")
   field(ZRSV, "MAJOR")

--- a/tprTriggerApp/Db/devTprInfo.db
+++ b/tprTriggerApp/Db/devTprInfo.db
@@ -1,0 +1,86 @@
+#
+# This db file can be loaded into an IOC with or w/o an TPR
+# We recommend adding this to each IOC that supports TPRs so
+# scripts are able to derive the TPR and trigger info from
+# each device's PV prefix.
+#
+# Required macros:
+#	DEV				Device PV prefix
+#	TPR_USED		0 = Unused, 1 = Used
+#
+# Optional macros:
+#	TPR				TPR PV prefix, defaults to $(DEV):NoTpr
+#	TRIG_CH			TPR Trigger channel number, defaults to 0
+#
+# It adds 2 new PVs for each device
+#	$(DEV):TPR_PV		PV prefix for this device's TPR
+#	$(DEV):TPR_TRIG_CH	TPR Trigger channel number for this device
+#
+# It also adds a new record, TprUsed with required macro
+#	$(TPR):TprUsed		bo record: 0 = Unused, 1 = Used
+#
+# The other records provide a minimal subset of records that
+# are compatible w/ their equivalent tprTrigger module records
+# to allow edm screens to work properly with or without an TPR
+#	$(TPR):VERERR
+#	$(TPR):RXLNKSTATUS
+#
+# Usage for devices with an TPR:
+#	Just add this line to your st.cmd file with appropriate definitions for DEV_PV, TPR_PV, and TRIG_CH
+#	You can load it before or after your evr db files, and can load one instance per device.
+# dbLoadRecords( "db/devTprInfo.db", "DEV=$DEV_PV,TPR=$TPR,TRIG_CH=$TRIG_CH,TPR_USED=1 )
+#
+# If your IOC supports some devices with TPRs and some without, follow the above usage
+# for devices with TPRs.   For devices without TPRs you can just load this. 
+# dbLoadRecords( "db/devTprInfo.db", "DEV=$DEV_PV,TPR_USED=0 )
+#
+# This allows your edm screens to use group visibility to hide or show our traditional
+# green diamond $(TPR):STATUS widget without getting white unconnected widget outlines
+# for the hidden $(TPR):STATUS widget for device screens w/ no TPR
+# Your edm screen should define the TPR macro as $(DEV):NoTpr or you can use your desired TPR_PV value.
+#
+
+record( stringout, "$(DEV):TPR_PV" )
+{
+	field( PINI, "YES" )
+	field( VAL, "$(TPR=$(DEV):NoTpr)" )
+}
+
+record( longout, "$(DEV):TPR_TRIG_CH" )
+{
+	field( PINI, "YES" )
+	field( VAL, "$(TRIG_CH=0)" )
+}
+
+record( bo, "$(TPR=$(DEV):NoTpr):TprUsed" )
+{
+	field( PINI, "YES" )
+	field( ZNAM, "Unused" )
+	field( ONAM, "Used" )
+	field( DOL,  "$(TPR_USED)" )
+}
+
+# Must match VERERR from tprTrigger module pcieSlave_tprTrig.db
+record(mbbi, "$(TPR):VERERR")
+{
+#  field(PINI, "YES")
+#  field(DOL, "1")
+  field(ZRVL, "0")
+  field(ZRST, "No Error")
+  field(ONVL, "1")
+  field(ONST, "Error")
+  field(ONSV, "MAJOR")
+}
+
+# Must match RXLNKSTATUS from tprTrigger module pcieSlave_tprTrig.db
+record(mbbi, "$(TPR):RXLNKSTATUS")
+{
+  field(PINI, "YES")
+#  field(DOL, "0")
+  field(ZRVL, "0")
+  field(ZRST, "Link Down")
+  field(ZRSV, "MAJOR")
+  field(ONVL, "1")
+  field(ONST, "Link Up")
+}
+

--- a/tprTriggerApp/Db/devTprInfo.db
+++ b/tprTriggerApp/Db/devTprInfo.db
@@ -9,50 +9,65 @@
 #	TPR_USED		0 = Unused, 1 = Used
 #
 # Optional macros:
-#	TPR				TPR PV prefix, defaults to $(DEV):NoTpr
-#	TRIG_CH			TPR Trigger channel number, defaults to 0
+#	TPR_PV			TPR master PV prefix, defaults to $(DEV):NoTpr
+#	TPS_PV			TPR slave  PV prefix, defaults to $(DEV):NoTpr
+#	TPR_CH			TPR channel number, defaults to 0
+#	TPR_TR			TPR trigger number, defaults to 0
 #
-# It adds 2 new PVs for each device
-#	$(DEV):TPR_PV		PV prefix for this device's TPR
-#	$(DEV):TPR_TRIG_CH	TPR Trigger channel number for this device
+# It adds 3 new PVs for each device
+#	$(DEV):TPR_PV		PV prefix for this device's master TPR
+#	$(DEV):TPS_PV		PV prefix for this device's slave  TPR
+#	$(DEV):TPR_CH		TPR Channel number for this device
+#	$(DEV):TPR_TR		TPR Trigger number for this device
 #
 # It also adds a new record, TprUsed with required macro
-#	$(TPR):TprUsed		bo record: 0 = Unused, 1 = Used
+#	$(TPS_PV):TprUsed	bo record: 0 = Unused, 1 = Used
 #
-# The other records provide a minimal subset of records that
+# The other record provides a minimal subset of records that
 # are compatible w/ their equivalent tprTrigger module records
 # to allow edm screens to work properly with or without an TPR
-#	$(TPR):VERERR
-#	$(TPR):RXLNKSTATUS
+#	$(TPS_PV):RXLNKSTATUS
 #
 # Usage for devices with an TPR:
-#	Just add this line to your st.cmd file with appropriate definitions for DEV_PV, TPR_PV, and TRIG_CH
+#	Just add this line to your st.cmd file with appropriate definitions for DEV, TPR_PV, and TPR_CH
 #	You can load it before or after your evr db files, and can load one instance per device.
-# dbLoadRecords( "db/devTprInfo.db", "DEV=$DEV_PV,TPR=$TPR,TRIG_CH=$TRIG_CH,TPR_USED=1 )
+# dbLoadRecords( "db/devTprInfo.db", "DEV=$(DEV),TPR_PV=$(TPR_PV),TPS_PV=$(TPS_PV),TPR_CH=$(TPR_CH),TPR_USED=1 )
 #
 # If your IOC supports some devices with TPRs and some without, follow the above usage
 # for devices with TPRs.   For devices without TPRs you can just load this. 
-# dbLoadRecords( "db/devTprInfo.db", "DEV=$DEV_PV,TPR_USED=0 )
+# dbLoadRecords( "db/devTprInfo.db", "DEV=$(DEV),TPR_USED=0 )
 #
 # This allows your edm screens to use group visibility to hide or show our traditional
-# green diamond $(TPR):STATUS widget without getting white unconnected widget outlines
-# for the hidden $(TPR):STATUS widget for device screens w/ no TPR
+# green diamond RXLINKSTATUS widget without getting white unconnected widget outlines
+# for the hidden RXLINKSTATUS widget for device screens w/ no TPR
 # Your edm screen should define the TPR macro as $(DEV):NoTpr or you can use your desired TPR_PV value.
 #
 
 record( stringout, "$(DEV):TPR_PV" )
 {
 	field( PINI, "YES" )
-	field( VAL, "$(TPR=$(DEV):NoTpr)" )
+	field( VAL, "$(TPR_PV=$(DEV):NoTpr)" )
 }
 
-record( longout, "$(DEV):TPR_TRIG_CH" )
+record( stringout, "$(DEV):TPS_PV" )
 {
 	field( PINI, "YES" )
-	field( VAL, "$(TRIG_CH=0)" )
+	field( VAL, "$(TPS_PV=$(DEV):NoTpr)" )
 }
 
-record( bo, "$(TPR=$(DEV):NoTpr):TprUsed" )
+record( longout, "$(DEV):TPR_CH" )
+{
+	field( PINI, "YES" )
+	field( VAL, "$(TPR_CH=0)" )
+}
+
+record( longout, "$(DEV):TPR_TR" )
+{
+	field( PINI, "YES" )
+	field( VAL, "$(TPR_TR=0)" )
+}
+
+record( bo, "$(TPS_PV=$(DEV):NoTpr):TprUsed" )
 {
 	field( PINI, "YES" )
 	field( ZNAM, "Unused" )
@@ -60,23 +75,11 @@ record( bo, "$(TPR=$(DEV):NoTpr):TprUsed" )
 	field( DOL,  "$(TPR_USED)" )
 }
 
-# Must match VERERR from tprTrigger module pcieSlave_tprTrig.db
-record(mbbi, "$(TPR):VERERR")
-{
-#  field(PINI, "YES")
-#  field(DOL, "1")
-  field(ZRVL, "0")
-  field(ZRST, "No Error")
-  field(ONVL, "1")
-  field(ONST, "Error")
-  field(ONSV, "MAJOR")
-}
-
 # Must match RXLNKSTATUS from tprTrigger module pcieSlave_tprTrig.db
-record(mbbi, "$(TPR):RXLNKSTATUS")
+record(mbbi, "$(TPS_PV):RXLNKSTATUS")
 {
   field(PINI, "YES")
-#  field(DOL, "0")
+  field(INP,  "$(TPR_PV):RXLNKSTATUS CP NMS")
   field(ZRVL, "0")
   field(ZRST, "Link Down")
   field(ZRSV, "MAJOR")


### PR DESCRIPTION
This adds a DB file called devTprInfo.db.
It's used by python programs in PCDS to navigate from a device prefix to TPR related info like the TPR_PV prefix, the TPR trigger number, the TPR channel, and the link status.
For example, if the python program is showing a camera device with prefix CAM, it's trigger channel is `$(CAM):TPR_CH,` and it's TPR prefix is `$(CAM):TPR_PV.`