### PR TITLE
Wfs build support

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -48,12 +48,12 @@ SHARED_LIBRARIES=NO
 STATIC_BUILD=YES
 
 # Note using PACKAGE_SITE_TOP from LCLS for PCDS as well
+KM_PACKAGE_SITE_TOP:=$(PACKAGE_SITE_TOP)
 ifndef PACKAGE_SITE_TOP
 ifeq ($(T_A),rhel7-gcc494-x86_64)
 PACKAGE_SITE_TOP=/reg/g/pcds/package/WFSlibs
 endif
 endif
-KM_PACKAGE_SITE_TOP=/afs/slac/g/lcls/package
 
 # Location of Linux Kernel Modules:
 LINUX_KERNEL_MODULES=$(KM_PACKAGE_SITE_TOP)/linuxKernel_Modules

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -53,9 +53,10 @@ ifeq ($(T_A),rhel7-gcc494-x86_64)
 PACKAGE_SITE_TOP=/reg/g/pcds/package/WFSlibs
 endif
 endif
+KM_PACKAGE_SITE_TOP=/afs/slac/g/lcls/package
 
 # Location of Linux Kernel Modules:
-LINUX_KERNEL_MODULES=$(PACKAGE_SITE_TOP)/linuxKernel_Modules
+LINUX_KERNEL_MODULES=$(KM_PACKAGE_SITE_TOP)/linuxKernel_Modules
 ifeq ($(wildcard $(LINUX_KERNEL_MODULES)/*),)
 $(error LINUX_KERNEL_MODULES Not found: $(LINUX_KERNEL_MODULES))
 endif

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -49,7 +49,9 @@ STATIC_BUILD=YES
 
 # Note using PACKAGE_SITE_TOP from LCLS for PCDS as well
 ifndef PACKAGE_SITE_TOP
-PACKAGE_SITE_TOP=/afs/slac/g/lcls/package
+ifeq ($(T_A),rhel7-gcc494-x86_64)
+PACKAGE_SITE_TOP=/reg/g/pcds/package/WFSlibs
+endif
 endif
 
 # Location of Linux Kernel Modules:


### PR DESCRIPTION
This commit brings in Mike Browne's support for an IOC built w/ Thorlabs WFS, which required a gcc 4.9.4 compiler.
I helped Mike create a special TARGET_ARCH rhel7-gcc494-x86_64 in base/R7.0.2-2.0 and R7.0.3.1-2.0 and Mike built several packages using the gcc 4.9.4 compiler in /reg/g/pcds/package/WFSlibs to support the build.

It's not clear if we still need this TARGET_ARCH, but I don't think it hurts anything to include it here.
Jeremy's commit makes it build compatible w/ S3DF.