### PR TITLE
Change TPS_PV everywhere to TPE_PV for Timing Pattern Event control PVs

### DIFF
--- a/tprTriggerApp/Db/devTprInfo.db
+++ b/tprTriggerApp/Db/devTprInfo.db
@@ -10,28 +10,28 @@
 #
 # Optional macros:
 #	TPR_PV			TPR master PV prefix, defaults to $(DEV):NoTpr
-#	TPS_PV			TPR slave  PV prefix, defaults to $(DEV):NoTpr
+#	TPE_PV			TPR events PV prefix, defaults to $(DEV):NoTpr
 #	TPR_TR			TPR trigger number, defaults to 0
 #	TPR_CH			TPR channel number, defaults to TPR_TR
 #
 # It adds 4 new PVs for each device
-#	$(DEV):TPR_PV		PV prefix for this device's master TPR
-#	$(DEV):TPS_PV		PV prefix for this device's slave  TPR
+#	$(DEV):TPR_PV		PV prefix for this device's master TPR PVs
+#	$(DEV):TPE_PV		PV prefix for this device's event  PVs
 #	$(DEV):TPR_CH		TPR Channel number for this device
 #	$(DEV):TPR_TR		TPR Trigger number for this device
 #
 # It also adds a new record, TprUsed with required macro
-#	$(TPS_PV):TprUsed	bo record: 0 = Unused, 1 = Used
+#	$(TPE_PV):TprUsed	bo record: 0 = Unused, 1 = Used
 #
 # The other record provides a minimal subset of records that
 # are compatible w/ their equivalent tprTrigger module records
 # to allow edm screens to work properly with or without an TPR
-#	$(TPS_PV):RXLNKSTATUS
+#	$(TPE_PV):RXLNKSTATUS
 #
 # Usage for devices with an TPR:
 #	Just add this line to your st.cmd file with appropriate definitions for DEV, TPR_PV, and TPR_CH
 #	You can load it before or after your evr db files, and can load one instance per device.
-# dbLoadRecords( "db/devTprInfo.db", "DEV=$(DEV),TPR_PV=$(TPR_PV),TPS_PV=$(TPS_PV),TPR_CH=$(TPR_CH),TPR_USED=1 )
+# dbLoadRecords( "db/devTprInfo.db", "DEV=$(DEV),TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=$(TPR_CH),TPR_USED=1 )
 #
 # If your IOC supports some devices with TPRs and some without, follow the above usage
 # for devices with TPRs.   For devices without TPRs you can just load this. 
@@ -49,10 +49,10 @@ record( stringout, "$(DEV):TPR_PV" )
 	field( VAL, "$(TPR_PV=$(DEV):NoTpr)" )
 }
 
-record( stringout, "$(DEV):TPS_PV" )
+record( stringout, "$(DEV):TPE_PV" )
 {
 	field( PINI, "YES" )
-	field( VAL, "$(TPS_PV=$(DEV):NoTpr)" )
+	field( VAL, "$(TPE_PV=$(DEV):NoTpr)" )
 }
 
 record( longout, "$(DEV):TPR_CH" )
@@ -67,7 +67,7 @@ record( longout, "$(DEV):TPR_TR" )
 	field( VAL, "$(TPR_TR=0)" )
 }
 
-record( bo, "$(TPS_PV=$(DEV):NoTpr):TprUsed" )
+record( bo, "$(TPE_PV=$(DEV):NoTpr):TprUsed" )
 {
 	field( PINI, "YES" )
 	field( ZNAM, "Unused" )
@@ -75,8 +75,8 @@ record( bo, "$(TPS_PV=$(DEV):NoTpr):TprUsed" )
 	field( DOL,  "$(TPR_USED)" )
 }
 
-# Must match RXLNKSTATUS from tprTrigger module pcieSlave_tprTrig.db
-record(mbbi, "$(TPS_PV=$(DEV):NoTpr):RXLNKSTATUS" )
+# Must match RXLNKSTATUS from tprTrigger module tprDiag.db
+record(mbbi, "$(TPE_PV=$(DEV):NoTpr):RXLNKSTATUS" )
 {
   field(PINI, "YES")
   field(ZRVL, "0")

--- a/tprTriggerApp/edm/tprFull.edl
+++ b/tprTriggerApp/edm/tprFull.edl
@@ -179,6 +179,1245 @@ propagateMacros {
 icon
 endObjectProperties
 
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 8
+y 56
+w 180
+h 60
+lineColor index 3
+fill
+fillColor index 3
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 8
+y 48
+w 48
+h 16
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+value {
+  "Info"
+}
+endObjectProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 344
+y 56
+w 304
+h 60
+lineColor index 3
+fill
+fillColor index 3
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 344
+y 48
+w 132
+h 16
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+value {
+  "Fiducial Pattern Status"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 352
+y 68
+w 56
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 4
+useDisplayBg
+value {
+  "Fiducial"
+}
+endObjectProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 196
+y 56
+w 144
+h 60
+lineColor index 3
+fill
+fillColor index 3
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 196
+y 48
+w 80
+h 16
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+value {
+  "TPR Status"
+}
+endObjectProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 656
+y 56
+w 132
+h 60
+lineColor index 3
+fill
+fillColor index 3
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 656
+y 48
+w 80
+h 16
+font "helvetica-medium-r-12.0"
+fgColor index 14
+bgColor index 3
+value {
+  "      TREF"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 200
+y 64
+w 36
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 4
+useDisplayBg
+value {
+  "Link"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 660
+y 72
+w 124
+h 16
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 4
+useDisplayBg
+value {
+  "Reference Time (ns)"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 48
+y 64
+w 136
+h 20
+font "helvetica-medium-r-12.0"
+fgColor index 14
+bgColor index 4
+value {
+  "$(IOC)"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 48
+y 92
+w 136
+h 20
+font "helvetica-medium-r-12.0"
+fgColor index 14
+bgColor index 4
+value {
+  "$(TPR_PV)"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 16
+y 92
+w 28
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 4
+useDisplayBg
+value {
+  "TPR"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 16
+y 64
+w 28
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 4
+useDisplayBg
+value {
+  "IOC"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 352
+y 92
+w 56
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 4
+useDisplayBg
+value {
+  "Fid. Rate"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 664
+y 92
+w 119
+h 20
+controlPv "$(TPR_PV):TREF"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 16
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+endObjectProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 8
+y 132
+w 866
+h 816
+lineColor index 3
+fill
+fillColor index 3
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 664
+y 948
+w 128
+h 20
+controlPv "$(IOC):TOD"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+fgAlarm
+bgColor index 12
+useDisplayBg
+precision 1
+nullColor index 0
+newPos
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 8
+y 124
+w 68
+h 16
+font "helvetica-bold-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+value {
+  "Triggers"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 572
+y 136
+w 98
+h 14
+font "helvetica-medium-i-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "* relative to TREF"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 116
+y 136
+w 420
+h 20
+font "helvetica-bold-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Note: Delay computations are based on the nominal 119MHz clock"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 16
+y 156
+w 60
+h 16
+font "helvetica-medium-i-10.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Trigger#"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 164
+y 156
+w 180
+h 16
+font "helvetica-medium-i-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Description"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 356
+y 156
+w 55
+h 16
+font "helvetica-medium-i-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "State"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 564
+y 156
+w 84
+h 16
+font "helvetica-medium-i-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Delay(ns)*"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 480
+y 156
+w 64
+h 16
+font "helvetica-medium-i-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Width(ns)"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 416
+y 156
+w 52
+h 16
+font "helvetica-medium-i-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Polarity"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 736
+y 156
+w 68
+h 16
+font "helvetica-medium-i-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Count"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 808
+y 156
+w 56
+h 16
+font "helvetica-medium-i-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Rate (Hz)"
+}
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 12
+y 172
+w 858
+h 64
+fgColor index 14
+bgColor index 0
+topShadowColor index 1
+botShadowColor index 14
+displaySource "menu"
+filePv "LOC\\\\emb-lcls1-tprTrig=0"
+sizeOfs 5
+numDsps 1
+displayFileName {
+  0 "tprTriggerScreens/emb-lcls1-tprTrig.edl"
+}
+menuLabel {
+  0 "Embedded Trigger"
+}
+symbols {
+  0 "TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=00,TPR_TR=00,TPR_SE=00"
+}
+replaceSymbols {
+  0 1
+}
+propagateMacros {
+  0 0
+}
+noScroll
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 12
+y 236
+w 858
+h 64
+fgColor index 14
+bgColor index 0
+topShadowColor index 1
+botShadowColor index 14
+displaySource "menu"
+filePv "LOC\\\\emb-lcls1-tprTrig=0"
+sizeOfs 5
+numDsps 1
+displayFileName {
+  0 "tprTriggerScreens/emb-lcls1-tprTrig.edl"
+}
+menuLabel {
+  0 "Embedded Trigger"
+}
+symbols {
+  0 "TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=01,TPR_TR=01,TPR_SE=01"
+}
+replaceSymbols {
+  0 1
+}
+propagateMacros {
+  0 0
+}
+noScroll
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 96
+y 156
+w 64
+h 16
+font "helvetica-medium-i-10.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Event Code"
+}
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 12
+y 300
+w 858
+h 64
+fgColor index 14
+bgColor index 0
+topShadowColor index 1
+botShadowColor index 14
+displaySource "menu"
+filePv "LOC\\\\emb-lcls1-tprTrig=0"
+sizeOfs 5
+numDsps 1
+displayFileName {
+  0 "tprTriggerScreens/emb-lcls1-tprTrig.edl"
+}
+menuLabel {
+  0 "Embedded Trigger"
+}
+symbols {
+  0 "TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=02,TPR_TR=02,TPR_SE=02"
+}
+replaceSymbols {
+  0 1
+}
+propagateMacros {
+  0 0
+}
+noScroll
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 12
+y 364
+w 858
+h 64
+fgColor index 14
+bgColor index 0
+topShadowColor index 1
+botShadowColor index 14
+displaySource "menu"
+filePv "LOC\\\\emb-lcls1-tprTrig=0"
+sizeOfs 5
+numDsps 1
+displayFileName {
+  0 "tprTriggerScreens/emb-lcls1-tprTrig.edl"
+}
+menuLabel {
+  0 "Embedded Trigger"
+}
+symbols {
+  0 "TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=03,TPR_TR=03,TPR_SE=03"
+}
+replaceSymbols {
+  0 1
+}
+propagateMacros {
+  0 0
+}
+noScroll
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 12
+y 428
+w 858
+h 64
+fgColor index 14
+bgColor index 0
+topShadowColor index 1
+botShadowColor index 14
+displaySource "menu"
+filePv "LOC\\\\emb-lcls1-tprTrig=0"
+sizeOfs 5
+numDsps 1
+displayFileName {
+  0 "tprTriggerScreens/emb-lcls1-tprTrig.edl"
+}
+menuLabel {
+  0 "Embedded Trigger"
+}
+symbols {
+  0 "TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=04,TPR_TR=04,TPR_SE=04"
+}
+replaceSymbols {
+  0 1
+}
+propagateMacros {
+  0 0
+}
+noScroll
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 12
+y 492
+w 858
+h 64
+fgColor index 14
+bgColor index 0
+topShadowColor index 1
+botShadowColor index 14
+displaySource "menu"
+filePv "LOC\\\\emb-lcls1-tprTrig=0"
+sizeOfs 5
+numDsps 1
+displayFileName {
+  0 "tprTriggerScreens/emb-lcls1-tprTrig.edl"
+}
+menuLabel {
+  0 "Embedded Trigger"
+}
+symbols {
+  0 "TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=05,TPR_TR=05,TPR_SE=05"
+}
+replaceSymbols {
+  0 1
+}
+propagateMacros {
+  0 0
+}
+noScroll
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 12
+y 556
+w 858
+h 64
+fgColor index 14
+bgColor index 0
+topShadowColor index 1
+botShadowColor index 14
+displaySource "menu"
+filePv "LOC\\\\emb-lcls1-tprTrig=0"
+sizeOfs 5
+numDsps 1
+displayFileName {
+  0 "tprTriggerScreens/emb-lcls1-tprTrig.edl"
+}
+menuLabel {
+  0 "Embedded Trigger"
+}
+symbols {
+  0 "TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=06,TPR_TR=06,TPR_SE=06"
+}
+replaceSymbols {
+  0 1
+}
+propagateMacros {
+  0 0
+}
+noScroll
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 12
+y 620
+w 858
+h 64
+fgColor index 14
+bgColor index 0
+topShadowColor index 1
+botShadowColor index 14
+displaySource "menu"
+filePv "LOC\\\\emb-lcls1-tprTrig=0"
+sizeOfs 5
+numDsps 1
+displayFileName {
+  0 "tprTriggerScreens/emb-lcls1-tprTrig.edl"
+}
+menuLabel {
+  0 "Embedded Trigger"
+}
+symbols {
+  0 "TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=07,TPR_TR=07,TPR_SE=07"
+}
+replaceSymbols {
+  0 1
+}
+propagateMacros {
+  0 0
+}
+noScroll
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 12
+y 684
+w 858
+h 64
+fgColor index 14
+bgColor index 0
+topShadowColor index 1
+botShadowColor index 14
+displaySource "menu"
+filePv "LOC\\\\emb-lcls1-tprTrig=0"
+sizeOfs 5
+numDsps 1
+displayFileName {
+  0 "tprTriggerScreens/emb-lcls1-tprTrig.edl"
+}
+menuLabel {
+  0 "Embedded Trigger"
+}
+symbols {
+  0 "TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=08,TPR_TR=08,TPR_SE=08"
+}
+replaceSymbols {
+  0 1
+}
+propagateMacros {
+  0 0
+}
+noScroll
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 12
+y 748
+w 858
+h 64
+fgColor index 14
+bgColor index 0
+topShadowColor index 1
+botShadowColor index 14
+displaySource "menu"
+filePv "LOC\\\\emb-lcls1-tprTrig=0"
+sizeOfs 5
+numDsps 1
+displayFileName {
+  0 "tprTriggerScreens/emb-lcls1-tprTrig.edl"
+}
+menuLabel {
+  0 "Embedded Trigger"
+}
+symbols {
+  0 "TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=09,TPR_TR=09,TPR_SE=09"
+}
+replaceSymbols {
+  0 1
+}
+propagateMacros {
+  0 0
+}
+noScroll
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 12
+y 812
+w 858
+h 64
+fgColor index 14
+bgColor index 0
+topShadowColor index 1
+botShadowColor index 14
+displaySource "menu"
+filePv "LOC\\\\emb-lcls1-tprTrig=0"
+sizeOfs 5
+numDsps 1
+displayFileName {
+  0 "tprTriggerScreens/emb-lcls1-tprTrig.edl"
+}
+menuLabel {
+  0 "Embedded Trigger"
+}
+symbols {
+  0 "TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=10,TPR_TR=10,TPR_SE=10"
+}
+replaceSymbols {
+  0 1
+}
+propagateMacros {
+  0 0
+}
+noScroll
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 12
+y 876
+w 858
+h 64
+fgColor index 14
+bgColor index 0
+topShadowColor index 1
+botShadowColor index 14
+displaySource "menu"
+filePv "LOC\\\\emb-lcls1-tprTrig=0"
+sizeOfs 5
+numDsps 1
+displayFileName {
+  0 "tprTriggerScreens/emb-lcls1-tprTrig.edl"
+}
+menuLabel {
+  0 "Embedded Trigger"
+}
+symbols {
+  0 "TPR_PV=$(TPR_PV),TPE_PV=$(TPE_PV),TPR_CH=11,TPR_TR=11,TPR_SE=11"
+}
+replaceSymbols {
+  0 1
+}
+propagateMacros {
+  0 0
+}
+noScroll
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 648
+y 156
+w 84
+h 16
+font "helvetica-medium-i-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Delay(ticks)*"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 256
+y 92
+w 80
+h 20
+controlPv "$(TPR_PV):VERERR"
+font "courier-medium-r-12.0"
+fontAlign "center"
+fgColor index 16
+fgAlarm
+bgColor index 12
+limitsFromDb
+precision 1
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 196
+y 92
+w 56
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 4
+useDisplayBg
+value {
+  "Vers Err"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 420
+y 68
+w 76
+h 20
+controlPv "$(TPR_PV):FIDCNT"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 16
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 244
+y 64
+w 56
+h 20
+controlPv "$(TPR_PV):RXLNKSTATUS"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 16
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+newPos
+objType "monitors"
+endObjectProperties
+
+# (Lines)
+object activeLineClass
+beginObjectProperties
+major 4
+minor 0
+release 1
+x 304
+y 60
+w 24
+h 24
+lineColor index 14
+fill
+fillColor index 15
+fillAlarm
+alarmPv "$(TPR_PV):RXLNKSTATUS"
+numPoints 5
+xPoints {
+  0 316
+  1 304
+  2 316
+  3 328
+  4 316
+}
+yPoints {
+  0 60
+  1 72
+  2 84
+  3 72
+  4 60
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 420
+y 92
+w 76
+h 20
+controlPv "$(TPR_PV):FIDRATE"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 16
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 508
+y 92
+w 132
+h 20
+controlPv "$(TPR_PV):SYS0_CLK"
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 16
+fgAlarm
+bgColor index 12
+limitsFromDb
+nullColor index 40
+smartRefresh
+useHexPrefix
+showUnits
+newPos
+objType "monitors"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 508
+y 72
+w 132
+h 20
+font "helvetica-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 4
+useDisplayBg
+value {
+  "App Clock Speed"
+}
+endObjectProperties
+
 # (Static Text)
 object activeXTextClass
 beginObjectProperties


### PR DESCRIPTION
This commit should have been part of the lcls1-lcls2-edm-screens pull request from 2 weeks ago.
The changes to devTprInfo.db for TPE_PV were needed for the edm screen changes.
The changes to tprFull.edl remove some widgets that got left in erroneously via a merging error.
They were hidden behind the embedded display widget that switches between emb-lcls1-tprTrig.edl
and emb-lcls2-tprTrig.edl.