### PR TITLE
Only show Invalid Table Msg once

### DIFF
--- a/tprTriggerApp/src/pcieTpr.cpp
+++ b/tprTriggerApp/src/pcieTpr.cpp
@@ -477,7 +477,12 @@ TimingPulseId timingGetLastFiducial(void)
     ts_tbl_t *p;
     if ( it == ts_tbl.end() )
     {
-        printf( "timingGetLastFiducial: Invalid timestamp table!\n" );
+		static	bool fInvalidTableMsgShow = false;
+		if ( !fInvalidTableMsgShow  )
+		{
+			printf( "timingGetLastFiducial: Invalid timestamp table!\n" );
+			fInvalidTableMsgShow = true;
+		}
         return 0LL;
     }
     p = &it->second;


### PR DESCRIPTION
Simple tweak to suppress endless error msgs if tpr table isn't initialized properly.